### PR TITLE
Improve search

### DIFF
--- a/src/search.ts
+++ b/src/search.ts
@@ -82,14 +82,25 @@ export const search = (
         const metadata = new grpc.Metadata();
         metadata.set('authorization', `bearer ${accessToken}`);
 
-        let lastPage = 0;
-
         // receive results
         const searchResponsesHeaders = new pbCommonModel.SubscriptionHeaders();
         searchResponsesHeaders.setClientappid(clientAppId);
         const searchResponseStream = client.receiveAllSearchResponses(searchResponsesHeaders, metadata);
 
+        let lastPage = 0;
         searchResponseStream.on('data', (handler) => {
+            const twins = handler.getPayload()?.getTwinsList();
+            const clientRef = handler.getHeaders()!.getClientref();
+            const page = parseInt(clientRef.split('_page')[1], 10);
+            if (twins?.length >= PAGE_LENGTH && page >= lastPage) {
+                lastPage += 1;
+                requestResultsPage(client, clientAppId, metadata, searchRequestPayload, scope, lastPage, emit);
+            }
+            if (twins?.length === 0 && page > 0) {
+                // Do not emit redundant responses if paginated search is called with global scope.
+                return;
+            }
+
             const searchResponsePayload = handler.getPayload();
             if (!searchResponsePayload) {
                 // eslint-disable-next-line no-console
@@ -112,15 +123,6 @@ export const search = (
                 status: 'OK',
                 results: searchResponsePayload,
             } as ISearchResult);
-
-            const twins = handler.getPayload()?.getTwinsList();
-            const clientRef = handler.getHeaders()!.getClientref();
-            const page = parseInt(clientRef.split('_page')[1], 10);
-
-            if (twins && twins.length >= PAGE_LENGTH && page >= lastPage) {
-                lastPage += 1;
-                requestResultsPage(client, clientAppId, metadata, searchRequestPayload, scope, lastPage, emit);
-            }
         });
 
         searchResponseStream.on('end', () => {


### PR DESCRIPTION
Commit message:
> ___Change search to return only non-empty responses when paginated___
> 
> Search request made with global scope and an offset will have a response for each and from all hosts.
> If a search response does not contain any twins:
> * for a requested offset/page - it should be filtered out;
> * but request was made for the first page - emit it.

Found this while working on Python client, tested with example script but need to test it against portal.
